### PR TITLE
Fix WIFI encryption type display in DropDown menu.

### DIFF
--- a/mtl/boot/boot.0.0.0.13.mtl
+++ b/mtl/boot/boot.0.0.0.13.mtl
@@ -1699,7 +1699,7 @@ fun webcrypt i=
 	else if i==IEEE80211_CRYPT_WEP then "WEP"
 	else if i==IEEE80211_CRYPT_WPA then "WPA"
   else if i==IEEE80211_CRYPT_WPA2 then "WPA2"
-	else "Unkown ";;
+	else "Unknown ";;
 
 fun isinscan s l=
 	if l==nil then 0
@@ -1709,7 +1709,7 @@ fun isinscan s l=
 fun selectscan s l=
 	if l!=nil then let hd l->[ssid mac bssid rssi channel rateset encryption] in
 	"<option value=\""::(filterweb ssid)::"\""::(if !strcmp ssid s then " selected")::">"::
-	(filterweb ssid)::" - "::(webcrypt encryption)::" - Channel "::(itoa channel)::" - Power "::(itoa rssi)::"</option>"::selectscan s tl l;;
+	(filterweb ssid)::" - "::(webcrypt encryption & 0xf0)::" - Channel "::(itoa channel)::" - Power "::(itoa rssi)::"</option>"::selectscan s tl l;;
 
 
 


### PR DESCRIPTION
Dropdown menu showed ’Unknown’ for WPA2 Wifis. It’ll show WPA2 now, as  proposed by @ccarlo64 here:
http://nabaztag.forumactif.fr/t15280p25-nabaztagtag-en-wpa2#389889


**Disclaimer** This is untested, will do later in time. Still unsure why the BitMask is applied on such a high level, feels for me it better happens in `webcrypt` function?

```php
fun webcrypt i=
	if i==IEEE80211_CRYPT_NONE then "None"
	else if i==IEEE80211_CRYPT_WEP then "WEP"
	else if i==IEEE80211_CRYPT_WPA then "WPA"
  else if (i &F0) ==IEEE80211_CRYPT_WPA2 then "WPA2"
	else "Unknown ";;
```

